### PR TITLE
Update model-keyword.txt

### DIFF
--- a/model-keyword.txt
+++ b/model-keyword.txt
@@ -2061,7 +2061,6 @@ d676dd55, deetz1
 d6b2691a, oddlyterrifying
 d6e9461b, abd
 d6e9d2b1, dvMJv4
-d7049739, cat
 d7149094, lnkdn photography
 d7cc8710, manyakis art style|rabbit girl
 d7f82d9e, melkor_manchin art style


### PR DESCRIPTION
Remove keyword 'Cat' for the standard stable diffusion model (v1-5-prunded-emaonly). 

Could be a hash but it basically makes the default checkpoint unusable by injecting cats.

see https://github.com/mix1009/model-keyword/issues/39
