### PR TITLE
Not auto enabled by default

### DIFF
--- a/scripts/model_keyword.py
+++ b/scripts/model_keyword.py
@@ -214,7 +214,7 @@ def get_settings():
 
     settings = {}
 
-    settings['is_enabled'] = 'True'
+    settings['is_enabled'] = 'False'
     settings['keyword_placement'] = 'keyword prompt'
     settings['multiple_keywords'] = 'keyword1, keyword2'
     settings['ti_keywords'] = 'None'


### PR DESCRIPTION
The auto enabling by default will cause it to apply keywords automatically without users knowledge unless they check the image parameters. Most extensions do not enable itself by default and neither should this. Also consider implementing the on_ui_settings script callback to enter the settings.txt settings to the actual settings menu in the Settings tab.